### PR TITLE
Add create_shared_db_metadata procedure and grant SELECT on shared metadata tables to secure share

### DIFF
--- a/script/snow_share/health_check_procedure.sql
+++ b/script/snow_share/health_check_procedure.sql
@@ -519,7 +519,7 @@ for (const shareDB of dbShares) {
   }).execute();
   if (!sharedTablesTableExists) {
     snowflake.createStatement({
-      sqlText: `CREATE OR REPLACE TABLE ${DATABASE_NAME}.${SCHEMA_NAME}.SHARED_TABLES AS
+      sqlText: `CREATE TABLE IF NOT EXISTS ${DATABASE_NAME}.${SCHEMA_NAME}.SHARED_TABLES AS
         SELECT * 
         FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()));`
     }).execute();
@@ -538,7 +538,7 @@ for (const shareDB of dbShares) {
   }).execute();
   if (!sharedViewsTableExists) {
     snowflake.createStatement({
-      sqlText: `CREATE OR REPLACE TABLE ${DATABASE_NAME}.${SCHEMA_NAME}.SHARED_VIEWS AS
+      sqlText: `CREATE TABLE IF NOT EXISTS ${DATABASE_NAME}.${SCHEMA_NAME}.SHARED_VIEWS AS
         SELECT * 
         FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()));`
     }).execute();
@@ -557,7 +557,7 @@ for (const shareDB of dbShares) {
   }).execute();
   if (!sharedColumnsTableExists) {
     snowflake.createStatement({
-      sqlText: `CREATE OR REPLACE TABLE ${DATABASE_NAME}.${SCHEMA_NAME}.SHARED_COLUMNS AS
+      sqlText: `CREATE TABLE IF NOT EXISTS ${DATABASE_NAME}.${SCHEMA_NAME}.SHARED_COLUMNS AS
         SELECT * 
         FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()));`
     }).execute();

--- a/script/snow_share/health_check_procedure.sql
+++ b/script/snow_share/health_check_procedure.sql
@@ -504,17 +504,16 @@ const executeSQL = (sqlText, column_name) => {
 };
 
 dbShares = executeSQL("SHOW SHARES;", "database_name");
+sharedTablesTableExists = executeSQL(getSQLText("SHARED_TABLES"), "TABLE_NAME");
+sharedTablesTableExists = sharedTablesTableExists.length > 0;
+
+sharedViewsTableExists = executeSQL(getSQLText("SHARED_VIEWS"), "TABLE_NAME");
+sharedViewsTableExists = sharedViewsTableExists.length > 0;
+
+sharedColumnsTableExists = executeSQL(getSQLText("SHARED_COLUMNS"), "TABLE_NAME");
+sharedColumnsTableExists = sharedColumnsTableExists.length > 0;
 
 for (const shareDB of dbShares) {
-  sharedTablesTableExists = executeSQL(getSQLText("SHARED_TABLES"), "TABLE_NAME");
-  sharedTablesTableExists = sharedTablesTableExists.length > 0;
-
-  sharedViewsTableExists = executeSQL(getSQLText("SHARED_VIEWS"), "TABLE_NAME");
-  sharedViewsTableExists = sharedViewsTableExists.length > 0;
-
-  sharedColumnsTableExists = executeSQL(getSQLText("SHARED_COLUMNS"), "TABLE_NAME");
-  sharedColumnsTableExists = sharedColumnsTableExists.length > 0;
-
   snowflake.createStatement({
     sqlText: `SHOW TABLES IN DATABASE ${shareDB};`
   }).execute();
@@ -524,6 +523,7 @@ for (const shareDB of dbShares) {
         SELECT * 
         FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()));`
     }).execute();
+    sharedTablesTableExists = true;
   }
   else {
     snowflake.createStatement({
@@ -542,6 +542,7 @@ for (const shareDB of dbShares) {
         SELECT * 
         FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()));`
     }).execute();
+    sharedViewsTableExists = true;
   }
   else {
     snowflake.createStatement({
@@ -560,6 +561,7 @@ for (const shareDB of dbShares) {
         SELECT * 
         FROM TABLE(RESULT_SCAN(LAST_QUERY_ID()));`
     }).execute();
+    sharedColumnsTableExists = true;
   }
   else {
     snowflake.createStatement({


### PR DESCRIPTION
Add shared metadata replication procedure and grant access to secure share
- Added create_shared_db_metadata stored procedure to replicate shared tables, views, and columns metadata.
- Granted SELECT on SHARED_TABLES, SHARED_VIEWS, and SHARED_COLUMNS to the S_SECURE_SHARE.


<img width="1386" height="860" alt="Screenshot 2025-07-18 at 11 18 38 AM" src="https://github.com/user-attachments/assets/aa8a4308-d7bb-4d7e-89a6-e6ae6e7c0ba9" />
<img width="1382" height="863" alt="Screenshot 2025-07-18 at 11 17 55 AM" src="https://github.com/user-attachments/assets/9f7e0cdf-c6af-4bbe-919b-6059135a7294" />
